### PR TITLE
import Required from typing_extensions to support older python version

### DIFF
--- a/pycardano/cip/cip68.py
+++ b/pycardano/cip/cip68.py
@@ -1,4 +1,5 @@
-from typing import Union, Dict, List, Any, TypedDict, Required
+from typing import Union, Dict, List, Any, TypedDict
+from typing_extensions import Required
 from dataclasses import dataclass
 from cbor2 import CBORTag
 


### PR DESCRIPTION
[CI is failing](https://github.com/Python-Cardano/pycardano/actions/runs/26793354953/job/78984416327) because it uses python 3.10, and `Required` is not in `typing` until 3.11

This should fix the error